### PR TITLE
fixed variable renaming issue

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -108,7 +108,6 @@ def main():
     project_name = config_json["Project_Name"]
     chain_name = config_json["Chain_Name"]
     
-    chain_name = json_object["Chain_Name"]
     rpc_url = get_rpc_url(chain_name)
     platform_key = get_etherscan_url()
 


### PR DESCRIPTION
on commit b8aef02, main.py:111: json_object variable was renamed to config_json, but later the name of the chain that came from the Python dict was still accessed from the old variable name